### PR TITLE
fix(ProductCardImage): change function toImageItem to insert photoSti…

### DIFF
--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -569,6 +569,16 @@ const toImageItem = (
   const imageInfo: ImageObject[] = [];
   const { title } = productItem;
 
+  if (productItem.photoStill) {
+    imageInfo.push({
+      "@type": "ImageObject" as const,
+      url: getImageUrl(imageBaseUrl, productItem.photoStill),
+      additionalType: "image",
+      alternateName: title,
+      disambiguatingDescription: `still`,
+    });
+  }
+
   if (productItem.photoSemiEnvironment) {
     imageInfo.push({
       "@type": "ImageObject" as const,
@@ -587,15 +597,7 @@ const toImageItem = (
       disambiguatingDescription: `panoramics`,
     });
   }
-  if (productItem.photoStill) {
-    imageInfo.push({
-      "@type": "ImageObject" as const,
-      url: getImageUrl(imageBaseUrl, productItem.photoStill),
-      additionalType: "image",
-      alternateName: title,
-      disambiguatingDescription: `still`,
-    });
-  }
+
   if (productItem.youtubeVideo) {
     imageInfo.push({
       "@type": "ImageObject" as const,


### PR DESCRIPTION
Notamos que, no resultado da busca, a foto mostrada era a photoSemiEnvironment ao invés da photoStill. Verifiquei que a escolha da imagem é feita pegando a primeira posição do array de imagens do produto. Por conta disso, fiz uma alteração na função que popula para que a photoStill seja inserida primeiro.